### PR TITLE
Add StakeStateV2 enum

### DIFF
--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -1,4 +1,4 @@
-#![no_std]
+#![cfg_attr(not(test), no_std)]
 
 #[cfg(not(feature = "no-entrypoint"))]
 mod entrypoint;

--- a/program/src/state/authorized.rs
+++ b/program/src/state/authorized.rs
@@ -1,0 +1,8 @@
+use pinocchio::pubkey::Pubkey;
+
+#[repr(C)]
+#[derive(Default, Debug, PartialEq, Eq, Clone, Copy)]
+pub struct Authorized {
+    pub staker: Pubkey,
+    pub withdrawer: Pubkey,
+}

--- a/program/src/state/delegation.rs
+++ b/program/src/state/delegation.rs
@@ -1,0 +1,69 @@
+use pinocchio::pubkey::Pubkey;
+
+use super::Epoch;
+
+#[repr(C)]
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub struct Delegation {
+    /// to whom the stake is delegated
+    pub voter_pubkey: Pubkey,
+    /// activated stake amount, set at delegate() time
+    stake: [u8; 8], // u64
+    /// epoch at which this stake was activated, std::Epoch::MAX if is a bootstrap stake
+    activation_epoch: Epoch,
+    /// epoch the stake was deactivated, std::Epoch::MAX if not deactivated
+    deactivation_epoch: Epoch,
+    /// how much stake we can activate per-epoch as a fraction of currently effective stake
+    #[deprecated(
+        since = "1.16.7",
+        note = "Please use `solana_sdk::stake::state::warmup_cooldown_rate()` instead"
+    )]
+    warmup_cooldown_rate: [u8; 8], //f64
+}
+
+impl Delegation {
+    #[inline(always)]
+    pub fn set_stake(&mut self, stake: u64) {
+        self.stake = stake.to_le_bytes();
+    }
+
+    #[inline(always)]
+    pub fn stake(&self) -> u64 {
+        u64::from_le_bytes(self.stake)
+    }
+
+    #[inline(always)]
+    pub fn set_activation_epoch(&mut self, activation_epoch: u64) {
+        self.activation_epoch = activation_epoch.to_le_bytes();
+    }
+
+    #[inline(always)]
+    pub fn activation_epoch(&self) -> u64 {
+        u64::from_le_bytes(self.activation_epoch)
+    }
+
+    #[inline(always)]
+    pub fn set_deactivation_epoch(&mut self, deactivation_epoch: u64) {
+        self.deactivation_epoch = deactivation_epoch.to_le_bytes();
+    }
+
+    #[inline(always)]
+    pub fn deactivation_epoch(&self) -> u64 {
+        u64::from_le_bytes(self.deactivation_epoch)
+    }
+}
+
+pub const DEFAULT_WARMUP_COOLDOWN_RATE: f64 = 0.25;
+
+impl Default for Delegation {
+    fn default() -> Self {
+        #[allow(deprecated)]
+        Self {
+            voter_pubkey: Pubkey::default(),
+            stake: 0u64.to_le_bytes(),
+            activation_epoch: 0u64.to_le_bytes(),
+            deactivation_epoch: u64::MAX.to_le_bytes(),
+            warmup_cooldown_rate: DEFAULT_WARMUP_COOLDOWN_RATE.to_le_bytes(),
+        }
+    }
+}

--- a/program/src/state/lockup.rs
+++ b/program/src/state/lockup.rs
@@ -1,0 +1,39 @@
+use pinocchio::pubkey::Pubkey;
+
+use super::Epoch;
+
+#[repr(C)]
+#[derive(Default, Debug, PartialEq, Eq, Clone, Copy)]
+pub struct Lockup {
+    /// UnixTimestamp at which this stake will allow withdrawal, unless the
+    ///   transaction is signed by the custodian
+    unix_timestamp: [u8; 8], //i64
+    /// epoch height at which this stake will allow withdrawal, unless the
+    ///   transaction is signed by the custodian
+    epoch: Epoch,
+    /// custodian signature on a transaction exempts the operation from
+    ///  lockup constraints
+    pub custodian: Pubkey,
+}
+
+impl Lockup {
+    #[inline(always)]
+    pub fn set_unix_timestamp(&mut self, unix_timestamp: i64) {
+        self.unix_timestamp = unix_timestamp.to_le_bytes();
+    }
+
+    #[inline(always)]
+    pub fn unix_timestamp(&self) -> i64 {
+        i64::from_le_bytes(self.unix_timestamp)
+    }
+
+    #[inline(always)]
+    pub fn set_epoch(&mut self, epoch: u64) {
+        self.epoch = epoch.to_le_bytes();
+    }
+
+    #[inline(always)]
+    pub fn epoch(&self) -> u64 {
+        u64::from_le_bytes(self.epoch)
+    }
+}

--- a/program/src/state/meta.rs
+++ b/program/src/state/meta.rs
@@ -1,0 +1,21 @@
+use super::{Authorized, Lockup};
+
+#[repr(C)]
+#[derive(Default, Debug, PartialEq, Eq, Clone, Copy)]
+pub struct Meta {
+    rent_exempt_reserve: [u8; 8], // u64
+    pub authorized: Authorized,
+    pub lockup: Lockup,
+}
+
+impl Meta {
+    #[inline(always)]
+    pub fn set_rent_exempt_reserve(&mut self, rent_exempt_reserve: u64) {
+        self.rent_exempt_reserve = rent_exempt_reserve.to_le_bytes();
+    }
+
+    #[inline(always)]
+    pub fn rent_exempt_reserve(&self) -> u64 {
+        u64::from_le_bytes(self.rent_exempt_reserve)
+    }
+}

--- a/program/src/state/mod.rs
+++ b/program/src/state/mod.rs
@@ -1,5 +1,57 @@
+pub mod authorized;
+pub mod delegation;
+pub mod lockup;
+pub mod meta;
 pub mod my_state;
+pub mod stake;
+pub mod stake_flags;
+pub mod stake_state_v2;
 pub mod utils;
 
+pub use authorized::*;
+pub use delegation::*;
+pub use lockup::*;
+pub use meta::*;
 pub use my_state::*;
+use pinocchio::{
+    account_info::{AccountInfo, Ref},
+    program_error::ProgramError,
+    ProgramResult,
+};
+pub use stake::*;
+pub use stake_flags::*;
+pub use stake_state_v2::*;
 pub use utils::*;
+
+pub type Epoch = [u8; 8]; //u64
+
+pub fn get_stake_state(
+    stake_account_info: &AccountInfo,
+) -> Result<Ref<StakeStateV2>, ProgramError> {
+    if stake_account_info.is_owned_by(&crate::ID) {
+        return Err(ProgramError::InvalidAccountOwner);
+    }
+
+    StakeStateV2::from_account_info(stake_account_info)
+}
+
+/// # Safety
+///
+/// The caller must ensure that it is safe to borrow the account data – e.g., there are
+/// no mutable borrows of the account data.
+pub unsafe fn get_stake_state_unchecked(
+    stake_account_info: &AccountInfo,
+) -> Result<&StakeStateV2, ProgramError> {
+    if stake_account_info.owner() != &crate::ID {
+        return Err(ProgramError::InvalidAccountOwner);
+    }
+
+    StakeStateV2::from_account_info_unchecked(stake_account_info)
+}
+
+pub fn set_stake_state(
+    _stake_account_info: &AccountInfo,
+    _new_state: &StakeStateV2,
+) -> ProgramResult {
+    todo!()
+}

--- a/program/src/state/stake.rs
+++ b/program/src/state/stake.rs
@@ -1,0 +1,22 @@
+use super::Delegation;
+
+#[repr(C)]
+#[derive(Debug, Default, PartialEq, Clone, Copy)]
+pub struct Stake {
+    pub delegation: Delegation,
+    /// credits observed is credits from vote account state when delegated or redeemed
+    credits_observed: [u8; 8], //u64
+}
+
+
+impl Stake {
+    #[inline(always)]
+    pub fn set_credits_observed(&mut self, credits_observed: u64) {
+        self.credits_observed = credits_observed.to_le_bytes();
+    }
+
+    #[inline(always)]
+    pub fn credits_observed(&self) -> u64 {
+        u64::from_le_bytes(self.credits_observed)
+    }
+}

--- a/program/src/state/stake_flags.rs
+++ b/program/src/state/stake_flags.rs
@@ -1,0 +1,35 @@
+#[repr(C)]
+#[derive(Copy, PartialEq, Eq, Clone, PartialOrd, Ord, Hash, Debug)]
+pub struct StakeFlags {
+    bits: u8,
+}
+
+impl StakeFlags {
+    pub const fn empty() -> Self {
+        Self { bits: 0 }
+    }
+
+    pub const fn contains(&self, other: Self) -> bool {
+        (self.bits & other.bits) == other.bits
+    }
+
+    pub fn remove(&mut self, other: Self) {
+        self.bits &= !other.bits;
+    }
+
+    pub fn set(&mut self, other: Self) {
+        self.bits |= other.bits;
+    }
+
+    pub const fn union(self, other: Self) -> Self {
+        Self {
+            bits: self.bits | other.bits,
+        }
+    }
+}
+
+impl Default for StakeFlags {
+    fn default() -> Self {
+        StakeFlags::empty()
+    }
+}

--- a/program/src/state/stake_state_v2.rs
+++ b/program/src/state/stake_state_v2.rs
@@ -1,0 +1,111 @@
+use pinocchio::{
+    account_info::{AccountInfo, Ref},
+    program_error::ProgramError,
+};
+
+use super::{Meta, Stake, StakeFlags};
+
+#[repr(u32)]
+#[derive(Debug, Default, PartialEq, Clone, Copy)]
+pub enum StakeStateV2 {
+    #[default]
+    Uninitialized,
+    Initialized(Meta),
+    Stake(Meta, Stake, StakeFlags),
+    RewardsPool,
+}
+
+impl StakeStateV2 {
+    /// The fixed number of bytes used to serialize each stake account
+    pub const fn size_of() -> usize {
+        200
+    }
+
+    #[inline]
+    pub fn from_account_info(
+        account_info: &AccountInfo,
+    ) -> Result<Ref<StakeStateV2>, ProgramError> {
+        if account_info.data_len() != Self::size_of() {
+            return Err(ProgramError::InvalidAccountData);
+        }
+
+        let data = account_info.try_borrow_data()?;
+        if data[0] > 3 {
+            return Err(ProgramError::InvalidAccountData);
+        }
+
+        Ok(Ref::map(data, |data| unsafe { Self::from_bytes(data) }))
+    }
+
+    /// # Safety
+    ///
+    /// The caller must ensure that it is safe to borrow the account data – e.g., there are
+    /// no mutable borrows of the account data.
+    #[inline]
+    pub unsafe fn from_account_info_unchecked(
+        account_info: &AccountInfo,
+    ) -> Result<&StakeStateV2, ProgramError> {
+        if account_info.data_len() != Self::size_of() {
+            return Err(ProgramError::InvalidAccountData);
+        }
+        let data = account_info.borrow_data_unchecked();
+        if data[0] > 3 {
+            return Err(ProgramError::InvalidAccountData);
+        }
+
+        Ok(Self::from_bytes(data))
+    }
+
+    /// # Safety
+    ///
+    /// The caller must ensure that `bytes` contains a valid representation of `StakeStateV2`.
+    #[inline(always)]
+    pub unsafe fn from_bytes(bytes: &[u8]) -> &Self {
+        &*(bytes.as_ptr() as *const Self)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::StakeStateV2;
+
+    #[test]
+    fn test_from_initialized() {
+        // StakeStateV2 Initialized(Meta { rent_exempt_reserve: 2282880, authorized: Authorized { staker: 531ngDyMQ95Ws12uWwf9k8bcBqtTWQ4enhNr9zKFZTHV, withdrawer: 531ngDyMQ95Ws12uWwf9k8bcBqtTWQ4enhNr9zKFZTHV }, lockup: Lockup { unix_timestamp: 0, epoch: 1, custodian: FAp2uc71WiitTgf8C4EzT9CNboKs9j8UnNAA2zJhpmNo } })
+        let data: [u8; 200] = [
+            1, 0, 0, 0, 128, 213, 34, 0, 0, 0, 0, 0, 59, 242, 204, 190, 54, 61, 5, 33, 184, 22,
+            185, 9, 8, 116, 164, 194, 234, 165, 126, 13, 237, 190, 6, 236, 191, 198, 111, 157, 70,
+            124, 157, 196, 59, 242, 204, 190, 54, 61, 5, 33, 184, 22, 185, 9, 8, 116, 164, 194,
+            234, 165, 126, 13, 237, 190, 6, 236, 191, 198, 111, 157, 70, 124, 157, 196, 0, 0, 0, 0,
+            0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 210, 135, 6, 69, 103, 142, 166, 59, 132, 215, 180,
+            188, 12, 10, 104, 133, 78, 242, 108, 76, 169, 33, 196, 149, 254, 142, 141, 219, 44, 39,
+            252, 88, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        ];
+
+        let val = unsafe { &*(data.as_ptr() as *const StakeStateV2) };
+
+        println!("{:?}", val);
+    }
+
+    #[test]
+    fn test_from_stake() {
+        // StakeStateV2 Stake(Meta { rent_exempt_reserve: 0, authorized: Authorized { staker: CJbnEm6uEhUQHyFt8bsYfDobbx6b39r47X4To5S89qRP, withdrawer: CJbnEm6uEhUQHyFt8bsYfDobbx6b39r47X4To5S89qRP }, lockup: Lockup { unix_timestamp: 0, epoch: 0, custodian: 11111111111111111111111111111111 } }, Stake { delegation: Delegation { voter_pubkey: DBF6UmjTW3vY5y58J5f3ePW9sMPgJ2wWJAygpFPsJxT4, stake: 1, activation_epoch: 1, deactivation_epoch: 18446744073709551615, warmup_cooldown_rate: 0.25 }, credits_observed: 969 }, StakeFlags { bits: 0 })
+        let data: [u8; 200] = [
+            2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 167, 242, 193, 121, 156, 42, 145, 92, 134, 135, 64,
+            238, 153, 60, 83, 202, 158, 70, 169, 101, 171, 142, 71, 92, 44, 123, 106, 167, 183, 80,
+            65, 150, 167, 242, 193, 121, 156, 42, 145, 92, 134, 135, 64, 238, 153, 60, 83, 202,
+            158, 70, 169, 101, 171, 142, 71, 92, 44, 123, 106, 167, 183, 80, 65, 150, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 180, 235, 252, 228, 206, 204, 148, 35, 80,
+            199, 23, 103, 170, 175, 11, 213, 246, 90, 116, 128, 217, 88, 50, 227, 163, 43, 95, 192,
+            68, 203, 54, 43, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 255, 255, 255, 255,
+            255, 255, 255, 255, 0, 0, 0, 0, 0, 0, 208, 63, 201, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        ];
+
+        let val = unsafe { &*(data.as_ptr() as *const StakeStateV2) };
+
+        println!("{:?}", val);
+    }
+}


### PR DESCRIPTION
Added StakeStateV2 enum and structs that is used: Meta, Authorized, Lockup, Stake, Delegation, StakeFlags