### PR TITLE
Apollo split authorizedchecked

### DIFF
--- a/program/src/consts.rs
+++ b/program/src/consts.rs
@@ -8,7 +8,3 @@ pub const LAMPORTS_PER_SOL: u64 = 1_000_000_000;
 pub const SYSVAR: Pubkey = pubkey!("Sysvar1111111111111111111111111111111111111");
 pub const DEFAULT_WARMUP_COOLDOWN_RATE: f64 = 0.25;
 pub const NEW_WARMUP_COOLDOWN_RATE: f64 = 0.09;
-pub const TAG_UNINITIALIZED: u32 = 0;
-pub const TAG_INITIALIZED: u32 = 1;
-pub const TAG_STAKE: u32 = 2;
-pub const TAG_REWARDS_POOL: u32 = 3;

--- a/program/src/consts.rs
+++ b/program/src/consts.rs
@@ -8,3 +8,7 @@ pub const LAMPORTS_PER_SOL: u64 = 1_000_000_000;
 pub const SYSVAR: Pubkey = pubkey!("Sysvar1111111111111111111111111111111111111");
 pub const DEFAULT_WARMUP_COOLDOWN_RATE: f64 = 0.25;
 pub const NEW_WARMUP_COOLDOWN_RATE: f64 = 0.09;
+pub const TAG_UNINITIALIZED: u32 = 0;
+pub const TAG_INITIALIZED: u32 = 1;
+pub const TAG_STAKE: u32 = 2;
+pub const TAG_REWARDS_POOL: u32 = 3;

--- a/program/src/error.rs
+++ b/program/src/error.rs
@@ -1,5 +1,3 @@
-use core::fmt;
-
 use pinocchio::program_error::ProgramError;
 
 pub trait FromPrimitive {
@@ -19,10 +17,6 @@ pub trait ToPrimitive {
 }
 
 /// Reasons the Stake might have had an error.
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_derive::Deserialize, serde_derive::Serialize)
-)]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum StakeError {
     // 0

--- a/program/src/instruction/authorized_checked.rs
+++ b/program/src/instruction/authorized_checked.rs
@@ -16,7 +16,7 @@ pub fn process_authorize_checked(
 
     // native asserts: 4 accounts (1 sysvar)
     let stake_account_info = next_account_info(account_info_iter)?;
-    let clock_info = next_account_info(account_info_iter)?;
+    let clock_info = next_account_info(account_info_iter)?; //Our own Struct
     let _old_stake_or_withdraw_authority_info = next_account_info(account_info_iter)?;
     let new_stake_or_withdraw_authority_info = next_account_info(account_info_iter)?;
 
@@ -40,7 +40,7 @@ pub fn process_authorize_checked(
         new_stake_or_withdraw_authority_info.key(),
         authority_type,
         custodian,
-        &clock,
+        clock,
     )?;
 
     Ok(())

--- a/program/src/instruction/authorized_checked.rs
+++ b/program/src/instruction/authorized_checked.rs
@@ -2,9 +2,7 @@ use pinocchio::{
     account_info::AccountInfo, program_error::ProgramError, pubkey::Pubkey, ProgramResult,
 };
 
-use crate::state::{
-    clock_from_account_info, collect_signers, do_authorize, next_account_info, StakeAuthorize,
-};
+use crate::state::{collect_signers, do_authorize, next_account_info, Clock, StakeAuthorize};
 
 pub fn process_authorize_checked(
     accounts: &[AccountInfo],
@@ -23,7 +21,7 @@ pub fn process_authorize_checked(
     // other accounts
     let option_lockup_authority_info = next_account_info(account_info_iter).ok();
 
-    let clock = *clock_from_account_info(clock_info)?;
+    let clock = *Clock::from_account_info(clock_info)?;
 
     if !new_stake_or_withdraw_authority_info.is_signer() {
         return Err(ProgramError::MissingRequiredSignature);

--- a/program/src/state/authorized.rs
+++ b/program/src/state/authorized.rs
@@ -1,8 +1,8 @@
-use pinocchio::{program_error::ProgramError, pubkey::Pubkey, sysvars::clock::Clock};
+use pinocchio::{program_error::ProgramError, pubkey::Pubkey};
 
 use crate::error::StakeError;
 
-use super::{Lockup, StakeAuthorize};
+use super::{Clock, Lockup, StakeAuthorize};
 
 #[repr(C)]
 #[derive(Default, Debug, PartialEq, Eq, Clone, Copy)]

--- a/program/src/state/lockup.rs
+++ b/program/src/state/lockup.rs
@@ -1,6 +1,6 @@
 use pinocchio::pubkey::Pubkey;
 
-use super::{Clock, Epoch};
+use super::{Clock, Epoch, UnixTimestamp};
 
 #[repr(C)]
 #[derive(Default, Debug, PartialEq, Eq, Clone, Copy)]

--- a/program/src/state/lockup.rs
+++ b/program/src/state/lockup.rs
@@ -1,6 +1,6 @@
-use pinocchio::{pubkey::Pubkey, sysvars::clock::Clock};
+use pinocchio::pubkey::Pubkey;
 
-use super::Epoch;
+use super::{Clock, Epoch};
 
 #[repr(C)]
 #[derive(Default, Debug, PartialEq, Eq, Clone, Copy)]
@@ -41,7 +41,7 @@ impl Lockup {
         if custodian == Some(&self.custodian) {
             return false;
         }
-        self.unix_timestamp > clock.unix_timestamp.to_le_bytes()
-            || self.epoch > clock.epoch.to_le_bytes()
+        i64::from_le_bytes(self.unix_timestamp) > i64::from_le_bytes(clock.unix_timestamp)
+            || u64::from_le_bytes(self.epoch) > u64::from_le_bytes(clock.epoch)
     }
 }

--- a/program/src/state/meta.rs
+++ b/program/src/state/meta.rs
@@ -1,6 +1,6 @@
-use pinocchio::{program_error::ProgramError, pubkey::Pubkey, sysvars::clock::Clock};
+use pinocchio::{program_error::ProgramError, pubkey::Pubkey};
 
-use super::{Authorized, Epoch, Lockup};
+use super::{Authorized, Clock, Epoch, Lockup};
 
 pub type UnixTimestamp = [u8; 8];
 

--- a/program/src/state/meta.rs
+++ b/program/src/state/meta.rs
@@ -1,8 +1,6 @@
-use pinocchio::{program_error::ProgramError, pubkey::Pubkey};
+use crate::{error::InstructionError, instruction::LockupArgs};
 
 use super::{Authorized, Clock, Epoch, Lockup};
-
-use super::{Authorized, Lockup};
 
 #[repr(C)]
 #[derive(Default, Debug, PartialEq, Eq, Clone, Copy)]

--- a/program/src/state/mod.rs
+++ b/program/src/state/mod.rs
@@ -38,7 +38,11 @@ pub fn get_stake_state(data: &[u8]) -> Result<StakeStateV2, ProgramError> {
         return Err(ProgramError::InvalidAccountData);
     }
 
-    let tag = u32::from_le_bytes(data[0..4].try_into().unwrap());
+    let tag = u32::from_le_bytes(
+        data[0..4]
+            .try_into()
+            .map_err(|_| ProgramError::InvalidInstructionData)?,
+    );
 
     let data_ptr = &data[4] as *const u8;
 

--- a/program/src/state/mod.rs
+++ b/program/src/state/mod.rs
@@ -16,7 +16,7 @@ pub use delegation::*;
 pub use lockup::*;
 pub use meta::*;
 use pinocchio::{
-    account_info::{AccountInfo, Ref, RefMut},
+    account_info::{AccountInfo, RefMut},
     program_error::ProgramError,
     ProgramResult,
 };
@@ -63,21 +63,6 @@ pub fn get_stake_state(data: &[u8]) -> Result<StakeStateV2, ProgramError> {
     }
 }
 
-/// # Safety
-///
-/// The caller must ensure that it is safe to borrow the account data – e.g., there are
-/// no mutable borrows of the account data.
-/*
-pub unsafe fn get_stake_state_unchecked(
-    stake_account_info: &AccountInfo,
-) -> Result<&StakeStateV2, ProgramError> {
-    if stake_account_info.owner() != &crate::ID {
-        return Err(ProgramError::InvalidAccountOwner);
-    }
-
-    StakeStateV2::from_account_info_unchecked(stake_account_info)
-}
-*/
 pub fn set_stake_state(
     mut acc_stake_state_data: RefMut<[u8]>,
     new_state: StakeStateV2,

--- a/program/src/state/mod.rs
+++ b/program/src/state/mod.rs
@@ -4,6 +4,7 @@ pub mod lockup;
 pub mod meta;
 pub mod stake;
 pub mod stake_authorize;
+pub mod stake_clock;
 pub mod stake_flags;
 pub mod stake_history;
 pub mod stake_history_sysvar;
@@ -15,34 +16,58 @@ pub use delegation::*;
 pub use lockup::*;
 pub use meta::*;
 use pinocchio::{
-    account_info::{AccountInfo, Ref},
+    account_info::{AccountInfo, Ref, RefMut},
     program_error::ProgramError,
     ProgramResult,
 };
 pub use stake::*;
 pub use stake_authorize::*;
+pub use stake_clock::*;
 pub use stake_flags::*;
 pub use stake_history::*;
 pub use stake_history_sysvar::*;
 pub use stake_state_v2::*;
 pub use utils::*;
 
+use crate::consts::{TAG_INITIALIZED, TAG_REWARDS_POOL, TAG_STAKE, TAG_UNINITIALIZED};
+
 pub type Epoch = [u8; 8]; //u64
 
-pub fn get_stake_state(
-    stake_account_info: &AccountInfo,
-) -> Result<Ref<StakeStateV2>, ProgramError> {
-    if stake_account_info.is_owned_by(&crate::ID) {
-        return Err(ProgramError::InvalidAccountOwner);
+pub fn get_stake_state(data: &[u8]) -> Result<StakeStateV2, ProgramError> {
+    if data.len() != 200 {
+        return Err(ProgramError::InvalidAccountData);
     }
 
-    StakeStateV2::from_account_info(stake_account_info)
+    let tag = u32::from_le_bytes(data[0..4].try_into().unwrap());
+
+    let data_ptr = &data[4] as *const u8;
+
+    unsafe {
+        match tag {
+            TAG_UNINITIALIZED => Ok(StakeStateV2::Uninitialized),
+            TAG_INITIALIZED => {
+                let meta = *(data_ptr as *const Meta);
+                Ok(StakeStateV2::Initialized(meta))
+            }
+            TAG_STAKE => {
+                let meta = *(data_ptr as *const Meta);
+                let stake_ptr = data_ptr.add(core::mem::size_of::<Meta>());
+                let stake = *(stake_ptr as *const Stake);
+                let flags_ptr = stake_ptr.add(core::mem::size_of::<Stake>());
+                let flags = *(flags_ptr as *const StakeFlags);
+                Ok(StakeStateV2::Stake(meta, stake, flags))
+            }
+            TAG_REWARDS_POOL => Ok(StakeStateV2::RewardsPool),
+            _ => Err(ProgramError::InvalidAccountData),
+        }
+    }
 }
 
 /// # Safety
 ///
 /// The caller must ensure that it is safe to borrow the account data – e.g., there are
 /// no mutable borrows of the account data.
+/*
 pub unsafe fn get_stake_state_unchecked(
     stake_account_info: &AccountInfo,
 ) -> Result<&StakeStateV2, ProgramError> {
@@ -52,25 +77,64 @@ pub unsafe fn get_stake_state_unchecked(
 
     StakeStateV2::from_account_info_unchecked(stake_account_info)
 }
-
+*/
 pub fn set_stake_state(
-    _stake_account_info: &AccountInfo,
-    _new_state: &StakeStateV2,
+    mut acc_stake_state_data: RefMut<[u8]>,
+    new_state: StakeStateV2,
 ) -> ProgramResult {
-    todo!()
-
-    /*
-
-    //--------------- Code to swap ------------
-     let serialized_size =
-        bincode::serialized_size(new_state).map_err(|_| ProgramError::InvalidAccountData)?;
-    if serialized_size > stake_account_info.data_len() as u64 {
-        return Err(ProgramError::AccountDataTooSmall);
+    if acc_stake_state_data.len() != 200 {
+        return Err(ProgramError::InvalidAccountData);
     }
 
-    let mut data = stake_account_info.try_borrow_mut_data()?;
-    bincode::serialize_into(&mut data[..], new_state).map_err(|_| ProgramError::InvalidAccountData)
-     */
+    let (tag, body_bytes): (u32, [u8; 196]) = match new_state {
+        StakeStateV2::Uninitialized => (TAG_UNINITIALIZED, [0u8; 196]),
+        StakeStateV2::Initialized(meta) => {
+            let mut body = [0u8; 196];
+            let meta_bytes = unsafe {
+                core::slice::from_raw_parts(
+                    &meta as *const Meta as *const u8,
+                    core::mem::size_of::<Meta>(),
+                )
+            };
+            body[..meta_bytes.len()].copy_from_slice(meta_bytes);
+            (TAG_INITIALIZED, body)
+        }
+        StakeStateV2::Stake(meta, stake, flags) => {
+            let mut body = [0u8; 196];
+            let meta_bytes = unsafe {
+                core::slice::from_raw_parts(
+                    &meta as *const Meta as *const u8,
+                    core::mem::size_of::<Meta>(),
+                )
+            };
+            let stake_bytes = unsafe {
+                core::slice::from_raw_parts(
+                    &stake as *const Stake as *const u8,
+                    core::mem::size_of::<Stake>(),
+                )
+            };
+            let flags_bytes = unsafe {
+                core::slice::from_raw_parts(
+                    &flags as *const StakeFlags as *const u8,
+                    core::mem::size_of::<StakeFlags>(),
+                )
+            };
+
+            let mut offset = 0;
+            body[offset..offset + meta_bytes.len()].copy_from_slice(meta_bytes);
+            offset += meta_bytes.len();
+            body[offset..offset + stake_bytes.len()].copy_from_slice(stake_bytes);
+            offset += stake_bytes.len();
+            body[offset..offset + flags_bytes.len()].copy_from_slice(flags_bytes);
+
+            (TAG_STAKE, body)
+        }
+        StakeStateV2::RewardsPool => (TAG_REWARDS_POOL, [0u8; 196]),
+    };
+
+    acc_stake_state_data[..4].copy_from_slice(&tag.to_le_bytes());
+    acc_stake_state_data[4..].copy_from_slice(&body_bytes);
+    Ok(())
 }
 
 // dont call this "move" because we have an instruction MoveLamports

--- a/program/src/state/mod.rs
+++ b/program/src/state/mod.rs
@@ -2,6 +2,7 @@ pub mod authorized;
 pub mod delegation;
 pub mod lockup;
 pub mod meta;
+pub mod redelegate_state;
 pub mod stake;
 pub mod stake_authorize;
 pub mod stake_clock;
@@ -10,14 +11,18 @@ pub mod stake_history;
 pub mod stake_history_sysvar;
 pub mod stake_state_v2;
 pub mod utils;
-pub mod redelegate_state;
 
 pub use authorized::*;
 pub use delegation::*;
 pub use lockup::*;
 pub use meta::*;
-use pinocchio::account_info::{AccountInfo, Ref, RefMut},
+use pinocchio::{
+    account_info::{AccountInfo, Ref, RefMut},
+    program_error::ProgramError,
+    ProgramResult,
+};
 
+pub use redelegate_state::*;
 pub use stake::*;
 pub use stake_authorize::*;
 pub use stake_clock::*;
@@ -26,46 +31,32 @@ pub use stake_history::*;
 pub use stake_history_sysvar::*;
 pub use stake_state_v2::*;
 pub use utils::*;
-pub use redelegate_state::*;
-
-
-use crate::consts::{TAG_INITIALIZED, TAG_REWARDS_POOL, TAG_STAKE, TAG_UNINITIALIZED};
 
 pub type Epoch = [u8; 8]; //u64
 pub type UnixTimestamp = [u8; 8]; //i64;
 
-pub fn get_stake_state(data: &[u8]) -> Result<StakeStateV2, ProgramError> {
-    if data.len() != 200 {
-        return Err(ProgramError::InvalidAccountData);
+pub fn get_stake_state(
+    stake_account_info: &AccountInfo,
+) -> Result<Ref<StakeStateV2>, ProgramError> {
+    if stake_account_info.is_owned_by(&crate::ID) {
+        return Err(ProgramError::InvalidAccountOwner);
     }
 
-    let tag = u32::from_le_bytes(
-        data[0..4]
-            .try_into()
-            .map_err(|_| ProgramError::InvalidInstructionData)?,
-    );
+    StakeStateV2::from_account_info(stake_account_info)
+}
 
-    let data_ptr = &data[4] as *const u8;
-
-    unsafe {
-        match tag {
-            TAG_UNINITIALIZED => Ok(StakeStateV2::Uninitialized),
-            TAG_INITIALIZED => {
-                let meta = *(data_ptr as *const Meta);
-                Ok(StakeStateV2::Initialized(meta))
-            }
-            TAG_STAKE => {
-                let meta = *(data_ptr as *const Meta);
-                let stake_ptr = data_ptr.add(core::mem::size_of::<Meta>());
-                let stake = *(stake_ptr as *const Stake);
-                let flags_ptr = stake_ptr.add(core::mem::size_of::<Stake>());
-                let flags = *(flags_ptr as *const StakeFlags);
-                Ok(StakeStateV2::Stake(meta, stake, flags))
-            }
-            TAG_REWARDS_POOL => Ok(StakeStateV2::RewardsPool),
-            _ => Err(ProgramError::InvalidAccountData),
-        }
+/// # Safety
+///
+/// The caller must ensure that it is safe to borrow the account data – e.g., there are
+/// no mutable borrows of the account data.
+pub unsafe fn get_stake_state_unchecked(
+    stake_account_info: &AccountInfo,
+) -> Result<&StakeStateV2, ProgramError> {
+    if stake_account_info.owner() != &crate::ID {
+        return Err(ProgramError::InvalidAccountOwner);
     }
+
+    StakeStateV2::from_account_info_unchecked(stake_account_info)
 }
 
 pub fn try_get_stake_state_mut(
@@ -76,65 +67,6 @@ pub fn try_get_stake_state_mut(
     }
 
     StakeStateV2::try_from_account_info_mut(stake_account_info)
-}
-
-pub fn set_stake_state(
-    mut acc_stake_state_data: RefMut<[u8]>,
-    new_state: StakeStateV2,
-) -> ProgramResult {
-    if acc_stake_state_data.len() != 200 {
-        return Err(ProgramError::InvalidAccountData);
-    }
-
-    let (tag, body_bytes): (u32, [u8; 196]) = match new_state {
-        StakeStateV2::Uninitialized => (TAG_UNINITIALIZED, [0u8; 196]),
-        StakeStateV2::Initialized(meta) => {
-            let mut body = [0u8; 196];
-            let meta_bytes = unsafe {
-                core::slice::from_raw_parts(
-                    &meta as *const Meta as *const u8,
-                    core::mem::size_of::<Meta>(),
-                )
-            };
-            body[..meta_bytes.len()].copy_from_slice(meta_bytes);
-            (TAG_INITIALIZED, body)
-        }
-        StakeStateV2::Stake(meta, stake, flags) => {
-            let mut body = [0u8; 196];
-            let meta_bytes = unsafe {
-                core::slice::from_raw_parts(
-                    &meta as *const Meta as *const u8,
-                    core::mem::size_of::<Meta>(),
-                )
-            };
-            let stake_bytes = unsafe {
-                core::slice::from_raw_parts(
-                    &stake as *const Stake as *const u8,
-                    core::mem::size_of::<Stake>(),
-                )
-            };
-            let flags_bytes = unsafe {
-                core::slice::from_raw_parts(
-                    &flags as *const StakeFlags as *const u8,
-                    core::mem::size_of::<StakeFlags>(),
-                )
-            };
-
-            let mut offset = 0;
-            body[offset..offset + meta_bytes.len()].copy_from_slice(meta_bytes);
-            offset += meta_bytes.len();
-            body[offset..offset + stake_bytes.len()].copy_from_slice(stake_bytes);
-            offset += stake_bytes.len();
-            body[offset..offset + flags_bytes.len()].copy_from_slice(flags_bytes);
-
-            (TAG_STAKE, body)
-        }
-        StakeStateV2::RewardsPool => (TAG_REWARDS_POOL, [0u8; 196]),
-    };
-
-    acc_stake_state_data[..4].copy_from_slice(&tag.to_le_bytes());
-    acc_stake_state_data[4..].copy_from_slice(&body_bytes);
-    Ok(())
 }
 
 // dont call this "move" because we have an instruction MoveLamports
@@ -159,4 +91,3 @@ pub fn relocate_lamports(
 
     Ok(())
 }
-

--- a/program/src/state/stake_clock.rs
+++ b/program/src/state/stake_clock.rs
@@ -1,16 +1,12 @@
-/// The unit of time given to a leader for encoding a block.
-///
-/// It is some some number of _ticks_ long.
+use pinocchio::{
+    account_info::{AccountInfo, Ref},
+    program_error::ProgramError,
+};
+
+use crate::consts::SYSVAR;
+
 pub type Slot = [u8; 8];
-
-/// The unit of time a given leader schedule is honored.
-///
-/// It lasts for some number of [`Slot`]s.
 pub type Epoch = [u8; 8];
-
-/// An approximate measure of real-world time.
-///
-/// Expressed as Unix time (i.e. seconds since the Unix epoch).
 pub type UnixTimestamp = [u8; 8];
 
 /// A representation of network time.
@@ -19,40 +15,34 @@ pub type UnixTimestamp = [u8; 8];
 #[repr(C)]
 #[derive(Copy, Clone, Default)]
 pub struct Clock {
-    /// The current `Slot`.
     pub slot: Slot,
-
-    /// The timestamp of the first `Slot` in this `Epoch`.
     pub epoch_start_timestamp: UnixTimestamp,
-
-    /// The current `Epoch`.
     pub epoch: Epoch,
-
-    /// The future `Epoch` for which the leader schedule has
-    /// most recently been calculated.
     pub leader_schedule_epoch: Epoch,
-
-    /// The approximate real world time of the current slot.
-    ///
-    /// This value was originally computed from genesis creation time and
-    /// network time in slots, incurring a lot of drift. Following activation of
-    /// the [`timestamp_correction` and `timestamp_bounding`][tsc] features it
-    /// is calculated using a [validator timestamp oracle][oracle].
-    ///
-    /// [tsc]: https://docs.solanalabs.com/implemented-proposals/bank-timestamp-correction
-    /// [oracle]: https://docs.solanalabs.com/implemented-proposals/validator-timestamp-oracle
     pub unix_timestamp: UnixTimestamp,
 }
 
-/// At 160 ticks/s, 64 ticks per slot implies that leader rotation and voting will happen
-/// every 400 ms. A fast voting cadence ensures faster finality and convergence
-pub const DEFAULT_TICKS_PER_SLOT: u64 = 64;
+impl Clock {
+    //Clock doesn't have a from_account_info, so we implemt it, inspired from TokenAccount Pinocchio impl
+    pub fn from_account_info(account_info: &AccountInfo) -> Result<Ref<Clock>, ProgramError> {
+        if account_info.data_len() != core::mem::size_of::<Clock>() {
+            return Err(ProgramError::InvalidAccountData);
+        }
 
-/// The default tick rate that the cluster attempts to achieve (160 per second).
-///
-/// Note that the actual tick rate at any given time should be expected to drift.
-pub const DEFAULT_TICKS_PER_SECOND: u64 = 160;
+        if !account_info.is_owned_by(&SYSVAR) {
+            return Err(ProgramError::InvalidAccountData);
+        }
 
-/// The expected duration of a slot (400 milliseconds).
-// Actually calculation is supposed to be derived DEFAULT_TICKS_PER_SLOT / DEFAULT_TICKS_PER_SECOND
-pub const DEFAULT_MS_PER_SLOT: u64 = 1_000 * DEFAULT_TICKS_PER_SLOT / DEFAULT_TICKS_PER_SECOND;
+        let data = account_info.try_borrow_data()?;
+
+        Ok(Ref::map(data, |data| unsafe { Self::from_bytes(data) }))
+    }
+
+    /// # Safety
+    ///
+    /// The caller must ensure that `bytes` contains a valid representation of `Clock`.
+    #[inline(always)]
+    pub unsafe fn from_bytes(bytes: &[u8]) -> &Self {
+        &*(bytes.as_ptr() as *const Self)
+    }
+}

--- a/program/src/state/stake_clock.rs
+++ b/program/src/state/stake_clock.rs
@@ -1,0 +1,58 @@
+/// The unit of time given to a leader for encoding a block.
+///
+/// It is some some number of _ticks_ long.
+pub type Slot = [u8; 8];
+
+/// The unit of time a given leader schedule is honored.
+///
+/// It lasts for some number of [`Slot`]s.
+pub type Epoch = [u8; 8];
+
+/// An approximate measure of real-world time.
+///
+/// Expressed as Unix time (i.e. seconds since the Unix epoch).
+pub type UnixTimestamp = [u8; 8];
+
+/// A representation of network time.
+///
+/// All members of `Clock` start from 0 upon network boot.
+#[repr(C)]
+#[derive(Copy, Clone, Default)]
+pub struct Clock {
+    /// The current `Slot`.
+    pub slot: Slot,
+
+    /// The timestamp of the first `Slot` in this `Epoch`.
+    pub epoch_start_timestamp: UnixTimestamp,
+
+    /// The current `Epoch`.
+    pub epoch: Epoch,
+
+    /// The future `Epoch` for which the leader schedule has
+    /// most recently been calculated.
+    pub leader_schedule_epoch: Epoch,
+
+    /// The approximate real world time of the current slot.
+    ///
+    /// This value was originally computed from genesis creation time and
+    /// network time in slots, incurring a lot of drift. Following activation of
+    /// the [`timestamp_correction` and `timestamp_bounding`][tsc] features it
+    /// is calculated using a [validator timestamp oracle][oracle].
+    ///
+    /// [tsc]: https://docs.solanalabs.com/implemented-proposals/bank-timestamp-correction
+    /// [oracle]: https://docs.solanalabs.com/implemented-proposals/validator-timestamp-oracle
+    pub unix_timestamp: UnixTimestamp,
+}
+
+/// At 160 ticks/s, 64 ticks per slot implies that leader rotation and voting will happen
+/// every 400 ms. A fast voting cadence ensures faster finality and convergence
+pub const DEFAULT_TICKS_PER_SLOT: u64 = 64;
+
+/// The default tick rate that the cluster attempts to achieve (160 per second).
+///
+/// Note that the actual tick rate at any given time should be expected to drift.
+pub const DEFAULT_TICKS_PER_SECOND: u64 = 160;
+
+/// The expected duration of a slot (400 milliseconds).
+// Actually calculation is supposed to be derived DEFAULT_TICKS_PER_SLOT / DEFAULT_TICKS_PER_SECOND
+pub const DEFAULT_MS_PER_SLOT: u64 = 1_000 * DEFAULT_TICKS_PER_SLOT / DEFAULT_TICKS_PER_SECOND;

--- a/program/src/state/stake_history_sysvar.rs
+++ b/program/src/state/stake_history_sysvar.rs
@@ -12,10 +12,7 @@
 //! [`SysvarId::id`]: https://docs.rs/solana-sysvar-id/latest/solana_sysvar_id/trait.SysvarId.html
 //! [`SysvarId::check_id`]: https://docs.rs/solana-sysvar-id/latest/solana_sysvar_id/trait.SysvarId.html#tymethod.check_id
 
-use pinocchio::{
-    pubkey::{self, Pubkey},
-    sysvars::clock::Epoch,
-};
+use pinocchio::sysvars::clock::Epoch;
 
 pub mod stake_history_id {
     pinocchio_pubkey::declare_id!("SysvarS1otHistory11111111111111111111111111");

--- a/program/src/state/stake_state_v2.rs
+++ b/program/src/state/stake_state_v2.rs
@@ -6,7 +6,7 @@ use pinocchio::{
 use super::{Authorized, Delegation, Lockup, Meta, Stake, StakeFlags};
 
 #[repr(C)]
-#[derive(Debug, Default, PartialEq, Clone, Copy)]
+#[derive(Debug, PartialEq, Clone, Copy)]
 pub enum StakeStateV2 {
     Uninitialized,
     Initialized(Meta),

--- a/program/src/state/stake_state_v2.rs
+++ b/program/src/state/stake_state_v2.rs
@@ -5,13 +5,6 @@ use pinocchio::{
 
 use super::{Authorized, Delegation, Lockup, Meta, Stake, StakeFlags};
 
-#[repr(C)]
-#[derive(Clone, Copy, Debug)]
-pub struct StakeStateUnion {
-    pub tag: u32,
-    pub data: [u8; 196], // 200 - 4 for the tag
-}
-
 #[derive(PartialEq, Clone, Copy, Debug)]
 pub enum StakeStateV2 {
     Uninitialized,

--- a/program/src/state/stake_state_v2.rs
+++ b/program/src/state/stake_state_v2.rs
@@ -5,16 +5,22 @@ use pinocchio::{
 
 use super::{Authorized, Delegation, Lockup, Meta, Stake, StakeFlags};
 
-#[repr(u32)]
-#[derive(Debug, Default, PartialEq, Clone, Copy)]
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+pub struct StakeStateUnion {
+    pub tag: u32,
+    pub data: [u8; 196], // 200 - 4 for the tag
+}
+
+#[derive(PartialEq, Clone, Copy, Debug)]
 pub enum StakeStateV2 {
-    #[default]
     Uninitialized,
     Initialized(Meta),
     Stake(Meta, Stake, StakeFlags),
     RewardsPool,
 }
-impl StakeStateV2 {
+
+impl<'a> StakeStateV2 {
     /// The fixed number of bytes used to serialize each stake account
     pub const fn size_of() -> usize {
         200
@@ -54,7 +60,6 @@ impl StakeStateV2 {
 
         Ok(Self::from_bytes(data))
     }
-
     /// # Safety
     ///
     /// The caller must ensure that `bytes` contains a valid representation of `StakeStateV2`.
@@ -111,7 +116,6 @@ impl StakeStateV2 {
         }
     }
 }
-
 #[cfg(test)]
 mod test {
     use super::StakeStateV2;

--- a/program/src/state/utils.rs
+++ b/program/src/state/utils.rs
@@ -2,13 +2,13 @@ use pinocchio::{
     account_info::{AccountInfo, Ref},
     program_error::ProgramError,
     pubkey::Pubkey,
-    sysvars::{clock, rent::Rent, Sysvar},
+    sysvars::{rent::Rent, Sysvar},
     ProgramResult, SUCCESS,
 };
 
 extern crate alloc;
 use super::{
-    get_stake_state, set_stake_state, Clock, Meta, StakeAuthorize, StakeStateV2,
+    get_stake_state, try_get_stake_state_mut, Clock, Meta, StakeAuthorize, StakeStateV2,
     DEFAULT_WARMUP_COOLDOWN_RATE,
 };
 use crate::consts::{
@@ -342,8 +342,9 @@ pub fn do_authorize(
     custodian: Option<&Pubkey>,
     clock: Clock,
 ) -> ProgramResult {
-    let stake_data = stake_account_info.try_borrow_mut_data()?;
-    match get_stake_state(&stake_data)? {
+    let mut stake_account: pinocchio::account_info::RefMut<'_, StakeStateV2> =
+        try_get_stake_state_mut(stake_account_info)?;
+    match *get_stake_state(stake_account_info)? {
         StakeStateV2::Initialized(mut meta) => {
             meta.authorized
                 .authorize(
@@ -353,8 +354,8 @@ pub fn do_authorize(
                     Some((&meta.lockup, &clock, custodian)),
                 )
                 .map_err(to_program_error)?;
-
-            set_stake_state(stake_data, StakeStateV2::Initialized(meta))
+            *stake_account = StakeStateV2::Initialized(meta);
+            Ok(())
         }
         StakeStateV2::Stake(mut meta, stake, stake_flags) => {
             meta.authorized
@@ -366,27 +367,11 @@ pub fn do_authorize(
                 )
                 .map_err(to_program_error)?;
 
-            set_stake_state(stake_data, StakeStateV2::Stake(meta, stake, stake_flags))
+            *stake_account = StakeStateV2::Stake(meta, stake, stake_flags);
+            Ok(())
         }
         _ => Err(ProgramError::InvalidAccountData),
     }
-}
-
-//Clock doesn't have a from_account_info, so we implemt it, inspired from TokenAccount Pinocchio impl
-pub fn clock_from_account_info(account_info: &AccountInfo) -> Result<Ref<Clock>, ProgramError> {
-    if account_info.data_len() != core::mem::size_of::<Clock>() {
-        return Err(ProgramError::InvalidAccountData);
-    }
-
-    if !account_info.is_owned_by(&SYSVAR) {
-        return Err(ProgramError::InvalidAccountData);
-    }
-
-    //not sure if we get the data this way, needs to be checked
-    let clock_acc = Ref::map(account_info.try_borrow_data()?, |data| unsafe {
-        &*(data.as_ptr() as *const Clock)
-    });
-    Ok(clock_acc)
 }
 
 // Means that no more than RATE of current effective stake may be added or subtracted per


### PR DESCRIPTION
- Breaking Changes in get_stake_state and set_stake_state
- split function updated accordingly to these changes and moved split_lamports == source_lamport_balance inside the match arm to avoid move
- Created Clock struct and stored it inside staked_clock.rs, this was created because we need the struct to have [u8;8] to be able to do from_account_info without any alignment issues since pinocchio Clock as u64 and i64. Next time I will move the cclock_from_account_info function (in utils) to be an impl of our new Clock struct
- Updated all other files, structs and impl that were affected by these changes